### PR TITLE
Change the timing to call switchVisibleViewController

### DIFF
--- a/PageController/PageController.swift
+++ b/PageController/PageController.swift
@@ -134,7 +134,6 @@ extension PageController {
         let visibleViewController = viewControllers[index]
         if visibleViewController == self.visibleViewController { return }
 
-        switchVisibleViewController(visibleViewController)
         // offsetX < 0 or offsetX > contentSize.width
         let frameOfContentSize = CGRect(x: 0, y: 0, width: scrollView.contentSize.width, height: scrollView.contentSize.height)
         for viewController in childViewControllers {
@@ -157,6 +156,8 @@ extension PageController {
         if exists.isEmpty {
             displayViewController(viewControllers[(index + 1).relative(viewControllers.count)], frame: frameForRightContentController)
         }
+
+        switchVisibleViewController(visibleViewController)
     }
 
     func switchVisibleViewController(viewController: UIViewController) {


### PR DESCRIPTION
I think switchVisibleViewController(visibleViewController) should be called after displayViewController was called.

It is because delegate method (didChangeVisibleController) is called just after changing visibleViewController.

When I want to change viewController that I don't want to show, I use the delegate method and change the viewController. 
But in "func loadPages(AtCenter index: Int)", displayViewController was called after switchVisibleViewController() then re-update viewController, so that I can't change viewController in didChangeVisibleController delegate method.

Is there any way to change viewController in didChangeVisibleController delegate method?
